### PR TITLE
Updating deps and prom-client calls for metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/skuid/js-spec#readme",
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "good": "^7.1.0",
-    "good-console": "^6.4.0",
-    "good-squeeze": "^5.0.1",
-    "hapi": "^16.1.0",
-    "lodash": "^4.17.4",
-    "pg": "^7.0.1",
-    "prom-client": "^10.0.2",
-    "wreck": "^12.2.2"
+    "bluebird": "^3.5.1",
+    "good": "^8.1.1",
+    "good-console": "^7.1.0",
+    "good-squeeze": "^5.0.2",
+    "hapi": "^17.3.1",
+    "lodash": "^4.17.5",
+    "pg": "^7.4.1",
+    "prom-client": "^11.0.0",
+    "wreck": "^14.0.2"
   }
 }

--- a/server/plugins/metrics/metrics.js
+++ b/server/plugins/metrics/metrics.js
@@ -4,12 +4,39 @@ const prom = require("prom-client");
 const Utils = require("./utils");
 
 const metric = {
-	version: new prom.Gauge("version_info", "The current git commit and node version.", ["commit", "node_version"]),
+	version: new prom.Gauge({
+		name: "version_info",
+		help: "The current git commit and node version.",
+		labelNames: [
+			"commit",
+			"node_version",
+		],
+	}),
 	http: {
 		requests: {
-			duration: new prom.Summary("http_request_duration_milliseconds", "request duration in milliseconds", ["method", "path", "status"]),
-			buckets: new prom.Histogram("http_request_buckets_milliseconds", "request duration buckets in milliseconds. Bucket size set to 500 and 2000 ms to enable apdex calculations with a T of 300ms", ["method", "path", "status"], { buckets: [ 500, 2000 ] })
-		}
+			duration: new prom.Summary({
+				name: "http_request_duration_milliseconds",
+				help: "request duration in milliseconds",
+				labelNames: [
+					"method",
+					"path",
+					"status",
+				],
+			}),
+			buckets: new prom.Histogram({
+				name: "http_request_buckets_milliseconds",
+				help: "request duration buckets in milliseconds. Bucket size set to 500 and 2000 ms to enable apdex calculations with a T of 300ms",
+				labelNames: [
+					"method",
+					"path",
+					"status",
+				],
+				buckets: [
+					500,
+					2000,
+				],
+			}),
+		},
 	}
 };
 


### PR DESCRIPTION
Prom-client now takes an object on the call to init the metrics rather than positional arguments. Updating the spec to reflect this change.